### PR TITLE
change to only check on pull request once release

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -3,7 +3,6 @@ name: Continuous Integration
 # This action works with pull requests and pushes
 on:
   pull_request:
-  push:
     branches:
       - main
       - release


### PR DESCRIPTION
## What does this PR do?
We are currently doing a ci check on both push and pull request of main. It should only be on pull request