### PR TITLE
Joshuadargan/routing to problem editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,9 @@ function App() {
             <PrivateRoute exact path={Routes.ProblemEditor}>
               <ProblemEditorPage />
             </PrivateRoute>
+            <PrivateRoute exact path={Routes.ProblemCreator}>
+              <ProblemEditorPage />
+            </PrivateRoute>
             <PrivateRoute exact path={Routes.Modules}>
               <ModulesPage />
             </PrivateRoute>

--- a/src/pages/ProblemEditor/ProblemEditorPage.tsx
+++ b/src/pages/ProblemEditor/ProblemEditorPage.tsx
@@ -2,8 +2,29 @@ import React from "react";
 import { ProblemEditorContainer } from "./ProblemEditorContainer/ProblemEditorContainer";
 import { LayoutContainer } from "../../shared/LayoutContainer";
 import { useAppSelector } from "../../app/common/hooks";
+import { useLocation, useParams } from "react-router-dom";
+
+interface ProblemEditorURL {
+  problemId?: string;
+}
+
+interface ProblemCreatorURL {
+  moduleId?: string;
+}
+
+interface ProblemLocationState {
+  moduleName?: string;
+}
 
 export const ProblemEditorPage = () => {
+  const { moduleId, problemId } = useParams<
+    ProblemEditorURL & ProblemCreatorURL
+  >();
+  const { moduleName } = useLocation<ProblemLocationState>().state;
+  console.log("moduleId: " + moduleId);
+  console.log("problemId: " + problemId);
+  console.log("moduleName: " + moduleName);
+
   const problemTitle = useAppSelector(
     (state) => state.problemEditorContainer.metadata.title
   );

--- a/src/pages/modules/components/ModuleAccordion.tsx
+++ b/src/pages/modules/components/ModuleAccordion.tsx
@@ -8,11 +8,12 @@ import {
 } from "@mui/material";
 import { ExpandMore, Add, Edit, AssignmentTurnedIn } from "@mui/icons-material";
 import { styled } from "@mui/material/styles";
-import { useHistory } from "react-router";
 import { useAppSelector } from "../../../app/common/hooks";
 import { IProblemBase } from "../../../shared/types";
 import { IAdminModule } from "../types";
 import { ModuleMenu } from "./";
+import { Routes } from "../../../shared/Routes.constants";
+import { Link } from "react-router-dom";
 
 const ModuleContent = styled(AccordionDetails)(({ theme }) => ({
   display: "flex",
@@ -54,7 +55,6 @@ interface moduleProps {
 }
 
 export function Modules({ setModuleToDelete, setProblemToGrade }: moduleProps) {
-  const history = useHistory();
   const modulesState = useAppSelector((state) => state.modules);
 
   return (
@@ -73,16 +73,21 @@ export function Modules({ setModuleToDelete, setProblemToGrade }: moduleProps) {
                     module={module}
                     setModuleToDelete={setModuleToDelete}
                   />
-
                   <NewProblemButton
                     startIcon={<Add />}
                     variant="outlined"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      history.push("/problem/create/" + module._id);
-                    }}
+                    onClick={(event) => event.stopPropagation()}
                   >
-                    Add Problem
+                    <Link
+                      to={{
+                        pathname:
+                          Routes.ProblemCreatorBaseWithoutId + module._id,
+                        state: { moduleName: module.name },
+                      }}
+                      style={{ color: "inherit", textDecoration: "inherit" }}
+                    >
+                      Add Problem
+                    </Link>
                   </NewProblemButton>
                 </AccordionSummary>
 
@@ -110,16 +115,24 @@ export function Modules({ setModuleToDelete, setProblemToGrade }: moduleProps) {
                       >
                         Grade
                       </ProblemAction>
-
                       <ProblemAction
                         startIcon={<Edit />}
                         size="small"
                         variant="outlined"
-                        onClick={() => {
-                          history.push("/problem/edit/" + problem._id);
-                        }}
                       >
-                        Edit
+                        <Link
+                          to={{
+                            pathname:
+                              Routes.ProblemEditorBaseWithoutId + problem._id,
+                            state: { moduleName: module.name },
+                          }}
+                          style={{
+                            color: "inherit",
+                            textDecoration: "inherit",
+                          }}
+                        >
+                          Edit
+                        </Link>
                       </ProblemAction>
                     </ButtonContainer>
                   </ModuleContent>

--- a/src/shared/Routes.constants.tsx
+++ b/src/shared/Routes.constants.tsx
@@ -2,6 +2,8 @@ export enum Routes {
   Login = "/admin/login",
   Modules = "/admin/modules",
   ProblemEditor = "/admin/problem/edit/:problemId",
+  ProblemEditorWithoutId = "/admin/problem/edit/", //To be used only when pushing to a route.
   ProblemCreator = "/admin/problem/create/:moduleId",
+  ProblemCreatorWithoutId = "/admin/problem/create/", //To be used only when pushing to a route.
   Code = "/code",
 }

--- a/src/shared/Routes.constants.tsx
+++ b/src/shared/Routes.constants.tsx
@@ -2,8 +2,8 @@ export enum Routes {
   Login = "/admin/login",
   Modules = "/admin/modules",
   ProblemEditor = "/admin/problem/edit/:problemId",
-  ProblemEditorWithoutId = "/admin/problem/edit/", //To be used only when pushing to a route.
+  ProblemEditorBaseWithoutId = "/admin/problem/edit/", //To be used only when pushing to a route.
   ProblemCreator = "/admin/problem/create/:moduleId",
-  ProblemCreatorWithoutId = "/admin/problem/create/", //To be used only when pushing to a route.
+  ProblemCreatorBaseWithoutId = "/admin/problem/create/", //To be used only when pushing to a route.
   Code = "/code",
 }

--- a/src/shared/Routes.constants.tsx
+++ b/src/shared/Routes.constants.tsx
@@ -1,6 +1,7 @@
 export enum Routes {
-  Login = "/login",
-  Modules = "/modules",
-  ProblemEditor = "/problem/edit/:id",
+  Login = "/admin/login",
+  Modules = "/admin/modules",
+  ProblemEditor = "/admin/problem/edit/:problemId",
+  ProblemCreator = "/admin/problem/create/:moduleId",
   Code = "/code",
 }


### PR DESCRIPTION
This PR sets up the routing for the problem creation and editing, passing in the id of the module id or problem id for problem creation and editing respectively. Also passes in the module name as a location prop.

Modules page
![image](https://user-images.githubusercontent.com/40403340/139503293-890786a1-5da4-48de-a38e-be438be5c1bf.png)

Add problem button
![image](https://user-images.githubusercontent.com/40403340/139503080-dabe7cb1-78cd-4452-85b8-7ca2c125849d.png)

Edit problem button
![image](https://user-images.githubusercontent.com/40403340/139503219-052878a0-37aa-45d6-9a0e-f625cc56754d.png)