### PR TITLE
Added a message for empty modules

### DIFF
--- a/src/pages/modules/components/ModuleAccordion.tsx
+++ b/src/pages/modules/components/ModuleAccordion.tsx
@@ -16,6 +16,7 @@ import { useHistory } from "react-router-dom";
 import { ModuleMenu } from "./";
 
 const Module = styled(Accordion)(({ theme }) => ({
+  position: "inherit",
   borderRadius: theme.spacing(0.5),
   "& .Mui-expanded": {
     borderBottomLeftRadius: 0,
@@ -102,46 +103,57 @@ export function Modules({ setModuleToDelete, setProblemToGrade }: moduleProps) {
                   </NewProblemButton>
                 </ModuleTitle>
 
-                {module.problems.map((problem, i) => (
-                  <ModuleContent key={i}>
-                    <Title>
-                      <b>
-                        Problem {module.number}.{i + 1}:
-                      </b>
-                      {` ${problem.title}`}
-                    </Title>
+                {module.problems.length > 0 ? (
+                  <>
+                    {module.problems.map((problem, i) => (
+                      <ModuleContent key={i}>
+                        <Title>
+                          <b>
+                            Problem {module.number}.{i + 1}:
+                          </b>
+                          {` ${problem.title}`}
+                        </Title>
 
-                    <ButtonContainer>
-                      <ProblemAction
-                        startIcon={<AssignmentTurnedIn />}
-                        size="small"
-                        variant="outlined"
-                        onClick={() => {
-                          let toGrade: IProblemBase = {
-                            _id: problem._id,
-                            title: problem.title,
-                          };
-                          setProblemToGrade(toGrade);
-                        }}
-                      >
-                        Grade
-                      </ProblemAction>
-                      <ProblemAction
-                        startIcon={<Edit />}
-                        size="small"
-                        variant="outlined"
-                        onClick={() => {
-                          history.push(
-                            Routes.ProblemEditorBaseWithoutId + problem._id,
-                            { moduleName: module.name }
-                          );
-                        }}
-                      >
-                        Edit
-                      </ProblemAction>
-                    </ButtonContainer>
+                        <ButtonContainer>
+                          <ProblemAction
+                            startIcon={<AssignmentTurnedIn />}
+                            size="small"
+                            variant="outlined"
+                            onClick={() => {
+                              let toGrade: IProblemBase = {
+                                _id: problem._id,
+                                title: problem.title,
+                              };
+                              setProblemToGrade(toGrade);
+                            }}
+                          >
+                            Grade
+                          </ProblemAction>
+                          <ProblemAction
+                            startIcon={<Edit />}
+                            size="small"
+                            variant="outlined"
+                            onClick={() => {
+                              history.push(
+                                Routes.ProblemEditorBaseWithoutId + problem._id,
+                                { moduleName: module.name }
+                              );
+                            }}
+                          >
+                            Edit
+                          </ProblemAction>
+                        </ButtonContainer>
+                      </ModuleContent>
+                    ))}
+                  </>
+                ) : (
+                  <ModuleContent>
+                    <Title>
+                      There are no problems for this module. Click add problem
+                      to begin.
+                    </Title>
                   </ModuleContent>
-                ))}
+                )}
               </Module>
             );
           })}


### PR DESCRIPTION
What does this PR do?

- This Pull Request adds a message for modules that do not have problems

The relevant files are currently under the `src/pages/modules` folder.

In `src/pages/modules` you can find

- `/components/ModuleAccordion.tsx ` we can find the accordions for the modules and their content.

---
Here is an image of the new Modules Page.

![image](https://user-images.githubusercontent.com/44170778/140830083-2e602ef7-759b-4d12-be34-7b5a438aa40c.png)

---
I decided to do this over making the icon vanish for two reasons:

1. I like being more explicit that there is no content with a message (better user experience)
2. It is a lot simpler than the way I think I could make the icon vanish