### PR TITLE
centered the login page loading and error message

### DIFF
--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -53,7 +53,7 @@ export function LoginPage(): React.ReactElement {
     />
   ) : (
     <LayoutContainer pageTitle="Admin Login">
-      <Stack>
+      <Stack justifyContent="center" alignItems="center">
         {authState.isLoading && <CircularProgress />}
         {authState.errorMessage && (
           <Alert


### PR DESCRIPTION
This PR centers the error message and loading symbol on the login page.

![image](https://user-images.githubusercontent.com/40403340/141205797-e913369f-5f42-4c9e-951b-5520615c10e2.png)

![image](https://user-images.githubusercontent.com/40403340/141205933-9e7dbb0d-f6b8-477c-ba4f-daebe380983e.png)
