### PR TITLE
Validate add/edit module, fix alert bug, make alert dismissable, and sort modules

### DIFF
--- a/src/pages/modules/ModulesPage.sagas.ts
+++ b/src/pages/modules/ModulesPage.sagas.ts
@@ -14,6 +14,7 @@ import {
   requestDeleteModule,
   requestDeleteModuleSuccess,
   requestDeleteModuleFailure,
+  closeDialog,
 } from "./ModulesPage.slice";
 import adminAPI from "../../app/common/apiClient";
 import { IModuleBase } from "../../shared/types";
@@ -53,6 +54,7 @@ function* handleAddModulesRequest(action: PayloadAction<IModuleBase>): any {
     };
 
     yield put(requestNewModuleSuccess(new_module));
+    yield put(closeDialog());
   } catch (e) {
     yield put(requestNewModuleFailure(e as Error));
   }
@@ -76,6 +78,7 @@ function* handleModifyModulesRequest(action: PayloadAction<IModuleBase>): any {
     // reminder: doesnt have the IAdminModule.problems property
     let new_module: IAdminModule = response.data;
     yield put(requestModifyModuleSuccess(new_module));
+    yield put(closeDialog());
   } catch (e) {
     yield put(requestModifyModuleFailure(e as Error));
   }

--- a/src/pages/modules/ModulesPage.slice.ts
+++ b/src/pages/modules/ModulesPage.slice.ts
@@ -66,7 +66,9 @@ export const moduleSlice = createSlice({
     requestNewModuleSuccess: (state, action: PayloadAction<IAdminModule>) => {
       return {
         ...state,
-        modules: [...state.modules, action.payload],
+        modules: [...state.modules, action.payload].sort(
+          (a, b) => a.number - b.number
+        ),
         feedback: {
           message: AlertMsg[action.type],
           type: AlertType.success,
@@ -109,6 +111,7 @@ export const moduleSlice = createSlice({
 
       // replace old module with new module
       state.modules = state.modules.fill(new_module, index, index + 1);
+      state.modules = state.modules.sort((a, b) => a.number - b.number);
 
       // TODO
       // Planning to add a title to the feedback message

--- a/src/pages/modules/components/ModuleDialog.tsx
+++ b/src/pages/modules/components/ModuleDialog.tsx
@@ -32,11 +32,18 @@ const dialogTitle = (status: DialogStatus) => {
   }
 };
 
+function isBlank(str: string) {
+  return !str || /^\s*$/.test(str);
+}
+
 export function ModuleDialog() {
   const dispatch = useAppDispatch();
   const { open, action, module } = useAppSelector(
     (state) => state.modules.dialogState
   );
+
+  const [numError, setNumError] = React.useState<boolean>(false);
+  const [nameError, setNameError] = React.useState<boolean>(false);
 
   const [dialogInput, setDialogInput] =
     React.useState<IModuleBase>(EmptyModule);
@@ -50,18 +57,19 @@ export function ModuleDialog() {
   }, [action, module]);
 
   const handleDialogSubmit = () => {
+    if (
+      numError ||
+      nameError ||
+      isBlank(dialogInput.name) ||
+      isNaN(dialogInput.number)
+    ) {
+      return;
+    }
     if (action === DialogStatus.CREATE) {
       dispatch(requestNewModule(dialogInput));
     } else if (action === DialogStatus.EDIT) {
       dispatch(requestModifyModule(dialogInput));
     }
-
-    // TODO:
-    //  dont close before checking
-    //  if action was successful
-    dispatch(closeDialog());
-    // make sure feedback is visible
-    // when the dialog is open
   };
 
   const FooterButtons = [
@@ -94,14 +102,19 @@ export function ModuleDialog() {
         </Typography>
 
         <NumberField
+          error={numError}
           label="Number"
+          id="standard-error-helper-text"
           variant="filled"
           inputProps={{ inputMode: "numeric", pattern: "[0-9]*" }}
           onChange={(event) => {
+            const num = parseInt(event.target.value);
             setDialogInput({
               ...dialogInput,
-              number: parseInt(event.target.value),
+              number: num,
             });
+            if (isNaN(num) || num < 0 || num > 1000000) setNumError(true);
+            else setNumError(false);
           }}
           defaultValue={
             action === DialogStatus.EDIT ? module.number : undefined
@@ -112,13 +125,17 @@ export function ModuleDialog() {
         />
 
         <NameTextField
+          error={nameError}
           label="Module Name"
+          id="standard-error-helper-text"
           variant="filled"
           onChange={(event) => {
             setDialogInput({
               ...dialogInput,
               name: event.target.value,
             });
+            if (isBlank(event.target.value)) setNameError(true);
+            else setNameError(false);
           }}
           defaultValue={action === DialogStatus.EDIT ? module.name : undefined}
           fullWidth

--- a/src/pages/modules/components/ModulesSnackbar.tsx
+++ b/src/pages/modules/components/ModulesSnackbar.tsx
@@ -14,7 +14,6 @@ export function ModulesSnackbar() {
     if (reason === "clickaway") {
       return;
     }
-
     dispatch(closeAlert());
   };
 
@@ -24,7 +23,12 @@ export function ModulesSnackbar() {
       autoHideDuration={3000}
       onClose={handleClose} // called after 6000 ms = 6 seconds
     >
-      <Alert variant="filled" severity={feedback.type} sx={{ width: "100%" }}>
+      <Alert
+        variant="filled"
+        severity={feedback.type}
+        sx={{ width: "100%" }}
+        onClose={handleClose}
+      >
         {feedback.message}
       </Alert>
     </Snackbar>

--- a/src/shared/LayoutContainer.tsx
+++ b/src/shared/LayoutContainer.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { useDispatch } from "react-redux";
 import { useHistory } from "react-router";
 import { requestLogout } from "../pages/Login/LoginPage.slice";
+import { closeAlert } from "../pages/modules/ModulesPage.slice";
 import { Routes } from "../shared/Routes.constants";
 
 export type ButtonColor = "primary" | "success" | "error" | "info" | "warning";
@@ -51,6 +52,7 @@ export const LayoutContainer = ({
               variant="contained"
               onClick={() => {
                 dispatch(requestLogout());
+                dispatch(closeAlert());
                 history.push(Routes.Login);
               }}
             >


### PR DESCRIPTION
This PR:

- Adds validation to add/edit module, 
- fixes alert bug when the token expires,
- makes the error alert dismissible, 
- does not close the add/edit dialog until success,
- and sorts modules on add/edit module