### PR TITLE
Changing log in request route

### DIFF
--- a/src/pages/Login/LoginPage.sagas.ts
+++ b/src/pages/Login/LoginPage.sagas.ts
@@ -6,19 +6,19 @@ import {
   requestLogin,
   receiveLoginFailure,
   receiveLoginSuccess,
-  IRequestLoginAction,
 } from "./LoginPage.slice";
 import apiClient from "../../app/common/apiClient";
+import { IRequestLoginAction, ILoginSuccess } from "./types";
+import { AxiosResponse } from "axios";
 
 function* handleRequestLogin(action: PayloadAction<IRequestLoginAction>): any {
   try {
-    const url = `${baseAPIURL}v1/user/login`;
-    const { data } = yield call(async () => {
+    const url = `${baseAPIURL}v1/auth/login`;
+    const { data }: AxiosResponse<ILoginSuccess> = yield call(async () => {
       return apiClient.post(url, action.payload);
     });
-    const { token } = data;
-    LocalStorage.setToken(token);
-    yield put(receiveLoginSuccess(token));
+
+    yield put(receiveLoginSuccess(data));
   } catch (e) {
     LocalStorage.checkUnauthorized(e);
     yield put(

--- a/src/pages/Login/LoginPage.slice.ts
+++ b/src/pages/Login/LoginPage.slice.ts
@@ -1,14 +1,13 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { LocalStorage } from "../../app/common/LocalStorage";
-
-export interface IAuthState {
-  isLoading: boolean;
-  errorMessage: string;
-}
+import { rolesEnum } from "../accounts/types";
+import { IAuthState, IRequestLoginAction, ILoginSuccess } from "./types";
 
 const initialAuthState: IAuthState = {
   isLoading: false,
   errorMessage: "",
+  loggedIn: false,
+  role: rolesEnum.TA,
 };
 
 /**
@@ -17,13 +16,6 @@ const initialAuthState: IAuthState = {
 export function getInitialAuthState(): IAuthState {
   return { ...initialAuthState };
 }
-
-export interface IRequestLoginAction {
-  username: string;
-  password: string;
-}
-
-//const requestLogin = createAction('requestLogin', withPayloadType<IRequestLoginAction>() );
 
 export const loginSlice = createSlice({
   name: "login",
@@ -36,23 +28,27 @@ export const loginSlice = createSlice({
         errorMessage: "",
       };
     },
-    receiveLoginSuccess(state, action) {
+    receiveLoginSuccess(state, action: PayloadAction<ILoginSuccess>) {
+      LocalStorage.setToken(action.payload.token);
       return {
         ...state,
         isLoading: false,
         errorMessage: "",
+        loggedIn: true,
+        role: action.payload.role,
       };
     },
     receiveLoginFailure(state, action) {
       return {
         ...state,
         isLoading: false,
+        loggedIn: true,
         errorMessage: action.payload,
       };
     },
     requestLogout(state) {
       LocalStorage.removeToken();
-      return { ...state, isLoading: false, authorizationToken: "" };
+      return { ...state, isLoading: false, loggedIn: false };
     },
     resetErrorMessage(state) {
       return {

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,13 +1,13 @@
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "../../app/common/store";
-import { requestLogin, resetErrorMessage } from "./LoginPage.slice";
-import { IRequestLoginAction } from "./LoginPage.slice";
 import { Field, Form, Formik } from "formik";
+import { RootState } from "../../app/common/store";
+import { useDispatch, useSelector } from "react-redux";
 import { FormTextField } from "../../shared/FormTextField";
+import { requestLogin, resetErrorMessage } from "./LoginPage.slice";
 import { LayoutContainer } from "../../shared/LayoutContainer";
-import { Routes } from "../../shared/Routes.constants";
-import { Redirect } from "react-router";
 import { LocalStorage } from "../../app/common/LocalStorage";
+import { Routes } from "../../shared/Routes.constants";
+import { IRequestLoginAction } from "./types";
+import { Redirect } from "react-router";
 import {
   Alert,
   Button,

--- a/src/pages/Login/__tests__/Login.reducer.spec.ts
+++ b/src/pages/Login/__tests__/Login.reducer.spec.ts
@@ -1,9 +1,11 @@
 import store from "../../../app/common/store";
+import { rolesEnum } from "../../accounts/types";
 import {
   receiveLoginFailure,
   receiveLoginSuccess,
   requestLogin,
 } from "../LoginPage.slice";
+import { IAuthState, ILoginSuccess } from "../types";
 
 describe("Auth Reducer", () => {
   jest.mock("../../../app/common/apiClient");
@@ -24,13 +26,18 @@ describe("Auth Reducer", () => {
   it("should handle receive login success", () => {
     const baseLoginState = store.getState().login;
 
-    const token = "token";
-    store.dispatch(receiveLoginSuccess(token));
+    const data: ILoginSuccess = {
+      token: "token",
+      role: rolesEnum.TA,
+    };
+    store.dispatch(receiveLoginSuccess(data));
 
-    const expected = {
+    const expected: IAuthState = {
       ...baseLoginState,
       errorMessage: "",
       isLoading: false,
+      loggedIn: true,
+      role: rolesEnum.TA,
     };
     expect(store.getState().login).toEqual(expected);
   });

--- a/src/pages/Login/types.ts
+++ b/src/pages/Login/types.ts
@@ -1,0 +1,18 @@
+import { rolesEnum } from "../accounts/types";
+
+export interface IAuthState {
+  isLoading: boolean;
+  errorMessage: string;
+  loggedIn: boolean;
+  role: rolesEnum;
+}
+
+export interface IRequestLoginAction {
+  username: string;
+  password: string;
+}
+
+export interface ILoginSuccess {
+  token: string;
+  role: rolesEnum;
+}

--- a/src/pages/accounts/AdminAccountsPage.tsx
+++ b/src/pages/accounts/AdminAccountsPage.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { Fade, Stack, duration, Container } from "@mui/material";
 import { LayoutContainer } from "../../shared/LayoutContainer";
+import { Fade, Stack, duration, Container } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../app/common/hooks";
+import { useHistory } from "react-router-dom";
 import {
   requestAccounts,
   unsetSelectedAccount,
@@ -13,8 +14,10 @@ import {
   DashboardProgress,
   AccountSnackbar,
 } from "./components";
+import { Routes } from "../../shared/Routes.constants";
 
 export function AdminAccountsPage() {
+  const history = useHistory();
   const dispatch = useAppDispatch();
   const dashboardState = useAppSelector((state) => state.accountManager);
 
@@ -46,6 +49,11 @@ export function AdminAccountsPage() {
   }, [loading]);
 
   const accountsHeaderButtons = [
+    {
+      label: "Manage Course Content",
+      onClick: () => history.push(Routes.Modules),
+      variant: "outlined",
+    },
     {
       label: "Add Admin User",
       onClick: () => setNewUserDialog(true),

--- a/src/pages/modules/ModulesPage.tsx
+++ b/src/pages/modules/ModulesPage.tsx
@@ -10,13 +10,18 @@ import {
 } from "./components";
 import { GradingDialog } from "../grading/components/GradingDialog";
 import { requestModules, openCreateDialog } from "./ModulesPage.slice";
+import { Routes } from "../../shared/Routes.constants";
 import { IAdminModule, NullModule } from "./types";
 import { IProblemBase } from "../../shared/types";
+import { rolesEnum } from "../accounts/types";
+import { useHistory } from "react-router-dom";
 
 const EmptyProblem: IProblemBase = { title: "" };
 
 export function ModulesPage() {
+  const history = useHistory();
   const dispatch = useAppDispatch();
+  const loginState = useAppSelector((state) => state.login);
   const modulesState = useAppSelector((state) => state.modules);
 
   // Module to delete - hooks
@@ -41,6 +46,19 @@ export function ModulesPage() {
     setToGrade(problem);
   };
 
+  const ProfessorHeaderButtons = [
+    {
+      label: "Manage Accounts",
+      onClick: () => history.push(Routes.Accounts),
+      variant: "outlined",
+    },
+    {
+      label: "Add Module",
+      onClick: () => dispatch(openCreateDialog()),
+      variant: "contained",
+    },
+  ];
+
   const moduleHeaderButtons = [
     {
       label: "Add Module",
@@ -49,12 +67,17 @@ export function ModulesPage() {
     },
   ];
 
+  const HeaderButtons =
+    loginState.role === rolesEnum.Professor && loginState.loggedIn
+      ? ProfessorHeaderButtons
+      : moduleHeaderButtons;
+
   React.useEffect(() => {
     dispatch(requestModules());
   }, [dispatch]);
 
   return (
-    <LayoutContainer pageTitle={"Modules"} actionButtons={moduleHeaderButtons}>
+    <LayoutContainer pageTitle={"Modules"} actionButtons={HeaderButtons}>
       <>
         <ModuleDialog />
 

--- a/src/pages/modules/components/ModuleDialog.tsx
+++ b/src/pages/modules/components/ModuleDialog.tsx
@@ -23,8 +23,6 @@ const NameTextField = styled(TextField)<TextFieldProps>(({ theme }) => ({
   marginTop: theme.spacing(2),
 }));
 
-
-
 function isInvalidNum(num: number) {
   return isNaN(num) || num < 0 || num > 1000000;
 }


### PR DESCRIPTION
Also stores current account information, and has a button to manage account for privileged accounts

There was a change to the log in route. Now we also have the current account's role.

# Description

Storing the current accounts role and offering a button to manage accounts to privileged accounts

# Motivation and Context

Better user experience and maintenance due to backend changes

# How Has This Been Tested?

Jest

# Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/44170778/144109963-a149aa2a-7945-492e-b48f-1281fb5b9866.png)

![image](https://user-images.githubusercontent.com/44170778/144109984-59b1b45d-b2b5-4c3d-a828-9ccb34f63a4d.png)


