### PR TITLE
added image scaling based on max width

### DIFF
--- a/src/pages/ProblemEditor/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/pages/ProblemEditor/MarkdownEditor/MarkdownEditor.tsx
@@ -1,8 +1,8 @@
 import { Divider, Stack, Typography } from "@mui/material";
 import React from "react";
-import ReactMarkdown from "react-markdown";
 import Editor from "@monaco-editor/react";
 import { FormikProps } from "formik";
+import { Markdown } from "../../../shared/Markdown";
 
 interface Props {
   form: FormikProps<any>;
@@ -36,9 +36,7 @@ export function MarkdownEditor({ form }: Props): React.ReactElement {
       <Stack width="50%" spacing={1} overflow="auto">
         <Typography component="h3">Preview</Typography>
         <Divider />
-        <ReactMarkdown>
-          {markdownText || "# Your problem statement here"}
-        </ReactMarkdown>
+        <Markdown markdownString={markdownText} />
       </Stack>
     </Stack>
   );

--- a/src/shared/Markdown.tsx
+++ b/src/shared/Markdown.tsx
@@ -6,6 +6,14 @@ interface Props {
   markdownString: string;
 }
 
+function Image(props: { alt: string } & any) {
+  return <img alt={props.alt} {...props} style={{ maxWidth: "100%" }} />;
+}
+
 export const Markdown = ({ markdownString }: Props) => (
-  <ReactMarkdown children={markdownString} remarkPlugins={[remarkGfm]} />
+  <ReactMarkdown
+    children={markdownString}
+    components={{ img: Image }}
+    remarkPlugins={[remarkGfm]}
+  />
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Allows for images to only be up to 100% of the max width of the container they are within, which prevents them from going beyond the container's bounds. 

It doesn't quite allow people to manually set the image size, but at least the image will scale with the container.

# Related Issue
see #140

# Motivation and Context
see #140

# How Has This Been Tested?
Manually on the create/edit problem markdown previewer and on the student code version

# Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/40403340/144147807-52e8b27f-1f30-482d-9576-7101f68f82bf.png)

Closes #140 

