### PR TITLE
Marcgabe15/change sizes

### DIFF
--- a/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
+++ b/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
@@ -63,6 +63,12 @@ export const CodeEditorView = ({ code, templatePackage }: CodeEditorProps) => {
   const problemId = useSelector(
     (state: RootState) => state.codeEditor.currentProblem?._id
   );
+  const fileType = useSelector(
+    (state: RootState) => state.codeEditor.currentProblem?.fileExtension
+  );
+  const navStructure = useSelector(
+    (state: RootState) => state.codeEditor.navStructure
+  );
   const { timeLimit, memoryLimit, buildCommand } = useSelector(
     (state: RootState) => {
       return {
@@ -82,11 +88,35 @@ export const CodeEditorView = ({ code, templatePackage }: CodeEditorProps) => {
   const handleEditorMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
     editorRef.current = editor;
   };
+
+  const generateFileName = () => {
+    let currentModuleNumber = -1;
+    let currentProblemNumber = -1;
+    let foundProblem = false;
+    for (let i = 0; i < navStructure.length; i++) {
+      for (let j = 0; j < navStructure[i].problems.length; j++) {
+        if (navStructure[i].problems[j]._id === problemId) {
+          foundProblem = true;
+          currentModuleNumber = i;
+          currentProblemNumber = j;
+          break;
+        }
+      }
+      if (foundProblem) {
+        break;
+      }
+    }
+    if (!foundProblem) {
+      return "edugator-code.cpp";
+    }
+    return `cop3530_${currentModuleNumber + 1}_${
+      currentProblemNumber + 1
+    }.${fileType}`;
+  };
   const handleDownload = () => {
     const blob = new Blob([currentCode]);
     const blobURL = URL.createObjectURL(blob);
-    const filename = "edugator-code.cpp";
-
+    const filename = generateFileName();
     // Create a new link
     const anchor = document.createElement("a");
     anchor.href = blobURL;

--- a/src/pages/CodeEditor/CodeEditorContainer/InputOutputView.tsx
+++ b/src/pages/CodeEditor/CodeEditorContainer/InputOutputView.tsx
@@ -107,7 +107,6 @@ export const InputOutputView = () => {
                 id="outlined-stdin"
                 multiline
                 minRows={6}
-                maxRows={6}
                 value={stdin}
                 onChange={handleStdinChange}
                 aria-describedby="outlined-stdin-text"

--- a/src/pages/CodeEditor/CodeEditorPage.tsx
+++ b/src/pages/CodeEditor/CodeEditorPage.tsx
@@ -264,6 +264,7 @@ export const CodeEditorPage = () => {
                   marginTop: 5,
                   marginRight: "auto",
                   marginLeft: "auto",
+                  zIndex: 300,
                 }}
                 onClose={() => {
                   dispatch(

--- a/src/pages/CodeEditor/CodeEditorPage.tsx
+++ b/src/pages/CodeEditor/CodeEditorPage.tsx
@@ -302,13 +302,13 @@ export const CodeEditorPage = () => {
                 </Allotment.Pane>
                 <Allotment.Pane minSize={350}>
                   <Allotment vertical snap={false}>
-                    <Allotment.Pane minSize={400}>
+                    <Allotment.Pane minSize={100}>
                       <CodeEditorView
                         code={currentProblem.code.body}
                         templatePackage={currentProblem.templatePackage}
                       />
                     </Allotment.Pane>
-                    <Allotment.Pane minSize={330}>
+                    <Allotment.Pane minSize={100}>
                       <InputOutputView />
                     </Allotment.Pane>
                   </Allotment>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
This pr fixes #165, #157, #143 #115

For #165: the file now renames to cop3530_moduleNumber_problemNumber.(cpp or .h)
For #157: list is collapsed on default and default sizes for right side of allotment are smaller
For #143: this is a back end issue and has been fixed in https://github.com/edugator-cise/edugator-staff-backend/commit/45c32f3fdba930dfa2d8427bdce31d63f5d2257b
For #115: fixed all issues for this
<!--- Describe your changes in detail -->

# Related Issue


# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# How Has This Been Tested?
Manual testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate):
![Screenshot from 2021-12-01 18-27-14](https://user-images.githubusercontent.com/33824219/144622729-a21ebd47-e4ed-4bdf-bb15-2d65e8f29ba7.png)
![Screenshot from 2021-12-03 09-26-17](https://user-images.githubusercontent.com/33824219/144622735-fac078d6-4a0b-40d0-986d-3d0af4b35bef.png)
