### PR TITLE
Changed file download name to include the problem name

### DIFF
--- a/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
+++ b/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
@@ -97,6 +97,7 @@ export const CodeEditorView = ({ code, templatePackage }: CodeEditorProps) => {
         if (problem._id === problemId) {
           foundProblem = true;
           currentProblemName = problem.problemName
+            .trim()
             .replace(" ", "_")
             .toLowerCase();
           break;
@@ -107,9 +108,9 @@ export const CodeEditorView = ({ code, templatePackage }: CodeEditorProps) => {
       }
     }
     if (!foundProblem) {
-      return "edugator-code.cpp";
+      return "not_found.cpp";
     }
-    return `cop3530_${currentProblemName}${fileType}`;
+    return `${currentProblemName}${fileType}`;
   };
   const handleDownload = () => {
     const blob = new Blob([currentCode]);

--- a/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
+++ b/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
@@ -92,11 +92,11 @@ export const CodeEditorView = ({ code, templatePackage }: CodeEditorProps) => {
   const generateFileName = () => {
     let currentProblemName = "";
     let foundProblem = false;
-    for (let i = 0; i < navStructure.length; i++) {
-      for (let j = 0; j < navStructure[i].problems.length; j++) {
-        if (navStructure[i].problems[j]._id === problemId) {
+    for (const module of navStructure) {
+      for (const problem of module.problems) {
+        if (problem._id === problemId) {
           foundProblem = true;
-          currentProblemName = navStructure[i].problems[j].problemName
+          currentProblemName = problem.problemName
             .replace(" ", "_")
             .toLowerCase();
           break;

--- a/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
+++ b/src/pages/CodeEditor/CodeEditorContainer/CodeEditorView.tsx
@@ -90,15 +90,15 @@ export const CodeEditorView = ({ code, templatePackage }: CodeEditorProps) => {
   };
 
   const generateFileName = () => {
-    let currentModuleNumber = -1;
-    let currentProblemNumber = -1;
+    let currentProblemName = "";
     let foundProblem = false;
     for (let i = 0; i < navStructure.length; i++) {
       for (let j = 0; j < navStructure[i].problems.length; j++) {
         if (navStructure[i].problems[j]._id === problemId) {
           foundProblem = true;
-          currentModuleNumber = i;
-          currentProblemNumber = j;
+          currentProblemName = navStructure[i].problems[j].problemName
+            .replace(" ", "_")
+            .toLowerCase();
           break;
         }
       }
@@ -109,9 +109,7 @@ export const CodeEditorView = ({ code, templatePackage }: CodeEditorProps) => {
     if (!foundProblem) {
       return "edugator-code.cpp";
     }
-    return `cop3530_${currentModuleNumber + 1}_${
-      currentProblemNumber + 1
-    }${fileType}`;
+    return `cop3530_${currentProblemName}${fileType}`;
   };
   const handleDownload = () => {
     const blob = new Blob([currentCode]);


### PR DESCRIPTION
# Description
This PR changes the name of the file downloaded when the "Download Submission" button is clicked to include the project name. The format of the newly downloaded file is "cop3530_${currentProblemName}${fileType}".

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate):
