### PR TITLE
On click edit transition task for the problem edit buttons

### DIFF
--- a/src/pages/ProblemEditor/ProblemEditorContainer/ProblemEditorContainer.tsx
+++ b/src/pages/ProblemEditor/ProblemEditorContainer/ProblemEditorContainer.tsx
@@ -12,6 +12,11 @@ import { TestEditor } from "../TestEditor/TestEditorForm";
 import { ExampleValidator } from "./ExampleValidator";
 import { ProblemEditorNavigator } from "./ProblemEditorNavigator";
 import { WarningDialog } from "../Dialogs/WarningDialog";
+import { useDispatch } from "react-redux";
+import {
+    incrementActiveStep,
+    decrementActiveStep,
+  } from "./problemEditorContainerSlice";
 
 const steps = [
   "Metadata",
@@ -22,6 +27,7 @@ const steps = [
 ];
 
 export const ProblemEditorContainer = () => {
+    
   const activeStep = useAppSelector(
     (state) => state.problemEditorContainer.activeStep
   );
@@ -43,7 +49,30 @@ export const ProblemEditorContainer = () => {
     }
   };
 
+  const currentStepIsValid = useAppSelector((state) => {
+    switch (state.problemEditorContainer.activeStep) {
+      case 0:
+        return state.problemEditorContainer.metadataIsValid;
+      case 1:
+        return state.problemEditorContainer.problemIsValid;
+      case 2:
+        return state.problemEditorContainer.codeIsValid;
+      case 3:
+        return state.problemEditorContainer.serverConfigIsValid;
+      case 4:
+        return state.problemEditorContainer.testEditorIsValid;
+      default:
+        return false;
+    }
+  });
+
+  const dispatch = useDispatch();
+
   const formRef = useRef<FormikValues>();
+
+  const handleNext = () => {
+    if (currentStepIsValid) dispatch(incrementActiveStep());
+  };
 
   return (
     <Box display="flex" flexDirection="column" flexGrow={1} textAlign="left">
@@ -51,8 +80,8 @@ export const ProblemEditorContainer = () => {
         {steps.map((label, index) => {
           return (
             <Step key={index}>
-              <StepLabel>{label}</StepLabel>
-            </Step>
+              <StepLabel onClick={handleNext}>{label}</StepLabel>
+            </Step> 
           );
         })}
       </Stepper>

--- a/src/pages/ProblemEditor/ProblemEditorContainer/ProblemEditorContainer.tsx
+++ b/src/pages/ProblemEditor/ProblemEditorContainer/ProblemEditorContainer.tsx
@@ -13,9 +13,7 @@ import { ExampleValidator } from "./ExampleValidator";
 import { ProblemEditorNavigator } from "./ProblemEditorNavigator";
 import { WarningDialog } from "../Dialogs/WarningDialog";
 import { useDispatch } from "react-redux";
-import {
-    changeActiveStep
-  } from "./problemEditorContainerSlice";
+import { changeActiveStep } from "./problemEditorContainerSlice";
 
 const steps = [
   "Metadata",
@@ -26,7 +24,6 @@ const steps = [
 ];
 
 export const ProblemEditorContainer = () => {
-    
   const activeStep = useAppSelector(
     (state) => state.problemEditorContainer.activeStep
   );
@@ -79,8 +76,10 @@ export const ProblemEditorContainer = () => {
         {steps.map((label, index) => {
           return (
             <Step key={index}>
-              <StepLabel onClick={handleChange.bind(this, index)}>{label}</StepLabel>
-            </Step> 
+              <StepLabel onClick={handleChange.bind(this, index)}>
+                {label}
+              </StepLabel>
+            </Step>
           );
         })}
       </Stepper>

--- a/src/pages/ProblemEditor/ProblemEditorContainer/ProblemEditorContainer.tsx
+++ b/src/pages/ProblemEditor/ProblemEditorContainer/ProblemEditorContainer.tsx
@@ -14,8 +14,7 @@ import { ProblemEditorNavigator } from "./ProblemEditorNavigator";
 import { WarningDialog } from "../Dialogs/WarningDialog";
 import { useDispatch } from "react-redux";
 import {
-    incrementActiveStep,
-    decrementActiveStep,
+    changeActiveStep
   } from "./problemEditorContainerSlice";
 
 const steps = [
@@ -70,8 +69,8 @@ export const ProblemEditorContainer = () => {
 
   const formRef = useRef<FormikValues>();
 
-  const handleNext = () => {
-    if (currentStepIsValid) dispatch(incrementActiveStep());
+  const handleChange = (index: number) => {
+    if (currentStepIsValid) dispatch(changeActiveStep(index));
   };
 
   return (
@@ -80,7 +79,7 @@ export const ProblemEditorContainer = () => {
         {steps.map((label, index) => {
           return (
             <Step key={index}>
-              <StepLabel onClick={handleNext}>{label}</StepLabel>
+              <StepLabel onClick={handleChange.bind(this, index)}>{label}</StepLabel>
             </Step> 
           );
         })}

--- a/src/pages/ProblemEditor/ProblemEditorContainer/problemEditorContainerSlice.ts
+++ b/src/pages/ProblemEditor/ProblemEditorContainer/problemEditorContainerSlice.ts
@@ -162,6 +162,9 @@ export const problemEditorContainerSlice = createSlice({
         state.activeStep -= 1;
       }
     },
+    changeActiveStep: (state, action: PayloadAction<number>) => {
+        state.activeStep = action.payload;
+    },
 
     updateProblem: (state, action: PayloadAction<ProblemFields>) => {
       state.problem = action.payload;
@@ -292,6 +295,7 @@ export const {
   validateCurrentStep,
   incrementActiveStep,
   decrementActiveStep,
+  changeActiveStep,
   updateProblem,
   updateMetadata,
   updateCodeEditor,

--- a/src/pages/ProblemEditor/ProblemEditorContainer/problemEditorContainerSlice.ts
+++ b/src/pages/ProblemEditor/ProblemEditorContainer/problemEditorContainerSlice.ts
@@ -163,7 +163,7 @@ export const problemEditorContainerSlice = createSlice({
       }
     },
     changeActiveStep: (state, action: PayloadAction<number>) => {
-        state.activeStep = action.payload;
+      state.activeStep = action.payload;
     },
 
     updateProblem: (state, action: PayloadAction<ProblemFields>) => {


### PR DESCRIPTION
# Description

Implemented button click feature in the /admin/problem edit pages where you can click the headers with "Metadata", "Code Editor", etc instead of having to manually click next over and over.

# Motivation and Context

Makes it easier for TAs to edit questions without having to manually spam the next/back button when trying to change screens to a certain location for a problem

# How Has This Been Tested?

Didn't add any unit tests, tested it manually
