### PR TITLE
Added the ability to change the order of problems in a module

### DIFF
--- a/components/Modules/ModuleAccordion.tsx
+++ b/components/Modules/ModuleAccordion.tsx
@@ -114,7 +114,6 @@ const moveProblem = async (
     toast.success("Problem was moved successfully");
   } catch (e) {
     toast.error("Error moving problem");
-    console.log(e);
   }
 };
 

--- a/components/Modules/ModulesSlice.ts
+++ b/components/Modules/ModulesSlice.ts
@@ -1,6 +1,10 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { IModuleBase, IRequestMessage } from "lib/shared/types";
-import { IModuleState, IAdminModule, DialogStatus } from "components/Modules/types";
+import {
+  IModuleState,
+  IAdminModule,
+  DialogStatus,
+} from "components/Modules/types";
 
 const baseModuleState: IModuleState = {
   modules: [],
@@ -63,6 +67,34 @@ export const moduleSlice = createSlice({
         modules: new_modules,
       };
     },
+    changeProblemOrderSuccess: (
+      state,
+      action: PayloadAction<{
+        moduleId: string;
+        problemId: string;
+        direction: string;
+      }>
+    ) => {
+      const { moduleId, problemId } = action.payload;
+
+      const index = state.modules.findIndex(
+        (module) => module._id === moduleId
+      );
+      const problemIndex = state.modules[index].problems.findIndex(
+        (problem) => problem._id === problemId
+      );
+
+      const problem = state.modules[index].problems[problemIndex];
+      state.modules[index].problems = state.modules[index].problems.filter(
+        (problem) => problem._id !== problemId
+      );
+
+      if (action.payload.direction === "up") {
+        state.modules[index].problems.splice(problemIndex - 1, 0, problem);
+      } else {
+        state.modules[index].problems.splice(problemIndex + 1, 0, problem);
+      }
+    },
 
     /* Dialog Reducers  */
     openCreateDialog: (state) => {
@@ -112,8 +144,7 @@ export const moduleSlice = createSlice({
     },
 
     /* Other reducers */
-    closeAlert: (state) => {
-    },
+    closeAlert: (state) => {},
     // good for testing purposes
     clearState: (state) => {
       return {
@@ -129,6 +160,7 @@ export const {
   requestNewModuleSuccess,
   requestModifyModuleSuccess,
   requestDeleteModuleSuccess,
+  changeProblemOrderSuccess,
   openCreateDialog,
   openEditDialog,
   closeDialog,

--- a/constants/apiRoutes.ts
+++ b/constants/apiRoutes.ts
@@ -19,6 +19,7 @@ export const apiRoutes = {
     createProblem: "v1/admin/problem",
     editProblem: (id: string) => `v1/admin/problem/${id}`,
     putLesson: (id: string) => `v1/admin/lesson/${id}`,
-    createLesson: "v1/admin/lesson/"
+    createLesson: "v1/admin/lesson/",
+    changeProblemOrder: "v1/module/changeProblemOrder",
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

On the admin modules page, admins are now able to reorder the problems inside a module. When clicking on a module, each problem now has a up and down arrow to change the order of the problem. 

This requires this [pull request](https://github.com/edugator-cise/edugator-staff-backend/pull/128) for the backend to be merged as it uses a new route.

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate):
